### PR TITLE
Add ColorPicker reference to Desktop app

### DIFF
--- a/qBittorrentCompanion/qBittorrentCompanion.csproj
+++ b/qBittorrentCompanion/qBittorrentCompanion.csproj
@@ -15,6 +15,7 @@
 	</PropertyGroup>
 		<ItemGroup>
     <PackageReference Include="Avalonia" Version="11.2.2" />
+    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.2.2" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.2" />
     <PackageReference Include="Avalonia.Controls.TreeDataGrid" Version="11.1.0" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.2" />


### PR DESCRIPTION
When I tried to run the publish command `dotnet publish ./qBittorrentCompanion.Desktop/qBittorrentCompanion.Desktop.csproj -c Release -r win-x64 --self-contained -p:PublishSingleFile=true` I got the following error:
 
```
❯ dotnet publish ./qBittorrentCompanion.Desktop/qBittorrentCompanion.Desktop.csproj -c Release -r win-x64 --self-contained -p:PublishSingleFile=true
Restauração concluída (0,5s)
  RssPlugins êxito (0,1s) → RssPlugins\bin\Release\net8.0\RssPlugins.dll
  SeriesRssPlugin êxito (0,0s) → SeriesRssPlugin\bin\Release\net8.0\SeriesRssPlugin.dll
  qBittorrentCompanion falhou com2 erros e 2 avisos (0,3s)
    qBittorrentCompanion\qBittorrentCompanion\Views\LocalSettingsWindow.axaml.cs(153,47): error CS0246: O nome do tipo ou do namespace "ColorPicker" não pode ser encontrado (está faltando uma diretiva using ou uma referência de assembly?)
    qBittorrentCompanion\qBittorrentCompanion\Views\LocalSettingsWindow.axaml.cs(175,63): error CS0246: O nome do tipo ou do namespace "ColorChangedEventArgs" não pode ser encontrado (está faltando uma diretiva using ou uma referência de assembly?)
    qBittorrentCompanion\qBittorrentCompanion\ViewModels\SearchViewModel.cs(375,32): warning CS0108: "SearchViewModel.SizeOptions" oculta o membro herdado "BytesBaseViewModel.SizeOptions". Use a nova palavra-chave se foi pretendido ocultar.
    qBittorrentCompanion\qBittorrentCompanion\ViewModels\TorrentTrackerViewModel.cs(181,28): warning CS8767: A nulidade de tipos de referência no tipo de parâmetro 'propertyName' de 'IEnumerable TorrentTrackerViewModel.GetErrors(string propertyName)' não corresponde ao membro implementado implicitamente 'IEnumerable INotifyDataErrorInfo.GetErrors(string? propertyName)' (possivelmente devido a atributos de nulidade).

Construir falhou com2 erros e 2 avisos em 1,2s
```

Adding the ColorPicker package reference fixed the issue.

I am using Visual Studio 2022 and .NET 9.0.200

(Sorry for output is not in English, I was not able to change it)